### PR TITLE
fix for Android Q

### DIFF
--- a/jni/fake_dlfcn.c
+++ b/jni/fake_dlfcn.c
@@ -63,8 +63,12 @@ void *fake_dlopen(const char *libpath, int flags)
 	maps = fopen("/proc/self/maps", "r");
 	if(!maps) fatal("failed to open maps");
 
-	while(!found && fgets(buff, sizeof(buff), maps)) 
-	    if(strstr(buff,"r-xp") && strstr(buff,libpath)) found = 1;
+	while (fgets(buff, sizeof(buff), maps)) {
+        if ((strstr(buff, "r-xp") || strstr(buff, "r--p")) && strstr(buff, libpath)) {
+            found = 1;
+            break;
+        }
+    }
 
 	fclose(maps);
 


### PR DESCRIPTION
In android q, some so would be divided into several segments by kernel, first segment (elf header) is  r--p.

`70f410a000-70f41ca000 r--p 00000000 fc:00 2306                           /system/lib64/libart-compiler.so
 70f41ca000-70f43d0000 --xp 000c0000 fc:00 2306                           /system/lib64/libart-compiler.so
 70f43d0000-70f43d1000 rw-p 002c6000 fc:00 2306                           /system/lib64/libart-compiler.so
 70f43d1000-70f43e4000 r--p 002c7000 fc:00 2306                           /system/lib64/libart-compiler.so`